### PR TITLE
use "lexical_category" over "lemma" for new database build

### DIFF
--- a/Assets/DBScript.cs
+++ b/Assets/DBScript.cs
@@ -40,7 +40,7 @@ public class DBScript : MonoBehaviour
         }
         SQLiteCommand command = dictionaryConnection.CreateCommand();
         command.CommandType = System.Data.CommandType.Text;
-        command.CommandText = string.Format("SELECT definition, lemma FROM dictionary WHERE word=\"{0}\" COLLATE NOCASE ORDER BY id LIMIT 1", word);
+        command.CommandText = string.Format("SELECT definition, lexical_category FROM dictionary WHERE word=\"{0}\" COLLATE NOCASE ORDER BY id LIMIT 1", word);
         SQLiteDataReader reader = command.ExecuteReader();
         while (reader.Read()) {
             string definition = REGEX_WIKTIONARY_MARKUP.Replace(reader.GetString(0), "").Trim();


### PR DESCRIPTION
With the renaming of the "lemma" column in the database build tool to "lexical_category," the dictionary query will need to reference this column name on new databases.

This release: https://github.com/macdub/go-wiktionary-parse/releases/tag/v0.3.1-db